### PR TITLE
syntax: simplify most literal index expressions within arithmetic

### DIFF
--- a/syntax/simplify_test.go
+++ b/syntax/simplify_test.go
@@ -27,13 +27,14 @@ var simplifyTests = [...]simplifyTest{
 	{"${foo:(1):(2)}", "${foo:1:2}"},
 	{"a[(1)]=2", "a[1]=2"},
 	{"$(($a + ${b}))", "$((a + b))"},
+	{"((${a[0]}))", "((a[0]))"},
+	{"((${a[foo]}))", "((a[foo]))"},
 	noSimple("$((${!a} + ${#b}))"),
 	noSimple("a[$b]=2"),
 	noSimple("${a[$b]}"),
 	noSimple("${a[@]}"),
 	noSimple("((${a[@]}))"),
 	noSimple("((${a[*]}))"),
-	noSimple("((${a[0]}))"),
 	noSimple("(($3 == $#))"),
 
 	// test exprs


### PR DESCRIPTION
Exclude known problematic/unportable cases involving `*` and `@` instead of all index expressions.

To me, skipping simplifications of all index expressions within arithmetic because there are a few cases where it cannot be done is somewhat unfortunate. I believe the problematic cases are rare in practice, because expressions such as `${!a[*]}`, `${#a[*]}` where `*` and `@` are commonly present are already (and need to be) skipped due to other reasons besides what's in the index.